### PR TITLE
Fix-sign_up-display-FooterLogo-Small

### DIFF
--- a/app/assets/stylesheets/_signup.scss
+++ b/app/assets/stylesheets/_signup.scss
@@ -112,6 +112,12 @@ body{
         &__logo{
           margin: 0 auto;
           width: 185px;
+          .FooterLogo{
+            margin: 0 auto;
+            width: 80px;
+            height: 65px;
+            display: block;
+          }
         }
 
         &__copylight{

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,4 +4,6 @@ class ItemsController < ApplicationController
 
   def show
   end
+
+  
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -41,6 +41,6 @@
         .footer__center__content__img
           .footer__center__content__img__logo
             = link_to root_path, class: "" do
-              = image_tag("//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2845599746")
+              = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2845599746",class: 'FooterLogo'
           .footer__center__content__img__copylight
             © Furima,  Inc.


### PR DESCRIPTION
#what
新規会員登録のフッターの白の空白の修正
　ロゴの大きさを変更
#why
ビューが崩れているから