### PR TITLE
商品削除機能の追加

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -88,6 +88,7 @@
           -#       =icon('fas','flag', class: 'icon')
           -#       不適切な商品の通報
     -# 編集ボタン・削除ボタン追加4/13石崎
+    -# ログインしているかつ、商品seller_idが一致の場合"商品の編集＆商品の削除"を表示
     .EditDeleteContent
       - if user_signed_in? && current_user.id == @item.seller_id
         .EditDeleteContent__EditBtn
@@ -95,7 +96,8 @@
             = link_to "#",class: 'EditTextBtn' do
               商品の編集
             -# レコード削除確認済み4/14
-            = link_to "商品の削除", item_path(@item.id), method: :delete, data: { confirm: '削除しますか？' }, class: 'DeleteTextBtn' 
+            = link_to "商品の削除", item_path(@item.id), method: :delete, data: { confirm: "削除しますか？" }, class: 'DeleteTextBtn' 
+      -# ログインしているかつログインユーザーがseller_idでない時購入確認ボタンを表示
       - if user_signed_in? && current_user.id != @item.seller_id
         .BuyBtn
           .BuyBtn__Text


### PR DESCRIPTION
#What
商品削除機能の追加
#Why
登録された商品のレコードを削除させるため。
（カテゴリーテーブルのレコードは削除されない事を確認。）

↓gif商品出品者ログイン状態：編集、削除が可能
https://gyazo.com/f2b7fb34690899fb063338037c154db8
↓ログアウト状態：編集、購入、削除　が不可
https://gyazo.com/e5b49a6ef7cd416f41f341b0688c31ec
↓出品者以外がログイン状態：購入が可能
https://gyazo.com/750e73060efae06ef2c31b87a9fb4491