### PR TITLE
[WIP]active_hash gemを利用した運用へのリファクタ

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,0 +1,5 @@
+class Condition < ActiveHash::Base
+  self.data = [
+    {id: 0, name: '新品、未使用'},{id: 1, name:'未使用に近い'},{id:2, name:'目立った傷や汚れなし'},{id:3, name:'やや傷や汚れあり'},{id:4, name:'傷や汚れあり'},{id:5, name:'全体的に状態が悪い'}
+  ]
+end

--- a/app/models/days_to_ship.rb
+++ b/app/models/days_to_ship.rb
@@ -1,0 +1,5 @@
+class DaysToShip < ActiveHash::Base
+  self.data = [
+    {id: 0, name: '1~2日で発送'},{id: 1, name:'2~3日で発送'},{id:2, name: '4~7日で発送'}
+  ]
+end

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -1,0 +1,5 @@
+class DeliveryFee < ActiveHash::Base
+  self.data = [
+    {id: 0, name: '送料込み(出品者負担)'},{id: 1, name:'送料込み(出品者負担)'}
+  ]
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,8 +2,6 @@ class Item < ApplicationRecord
 
   validates :product_name,:category_id,:price,:condition,:description,:delivery_fee,:shipping_origin,:days_to_ship, presence: true
 
-
-
   has_many :images, dependent: :destroy
   # 子モデルへのレコード登録を可能にするための入力フォーム"field_for"メソッドを利用するために、以下記述を追加
   # 引数に"allow_destroy: true"を設定。
@@ -11,6 +9,13 @@ class Item < ApplicationRecord
   accepts_nested_attributes_for :images, allow_destroy: true
   # 商品削除機能実装時にエラーが出たため下記の１行をコメントアウト。ｂｙ石崎
   # has_many :comments, dependent: :destroy
+
+  #active_hashのアソシエーションを追記
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :delivery_fee
+  belongs_to_active_hash :days_to_ship
+  belongs_to_active_hash :condition
+
   belongs_to :user
   belongs_to :category
   belongs_to :buyer, class_name:'User', foreign_key: "buyer_id", optional: true

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -56,19 +56,42 @@
               
           %tr
             %th 商品の状態
-            %td=@item.condition
-              
+            %td
+              -case @item.condition_id
+              -when 0
+                = "新品、未使用"
+              -when 1
+                = "未使用に近い"
+              -when 2
+                = "目立った傷や汚れなし"
+              -when 3
+                = "やや傷や汚れあり"
+              -when 4
+                = "傷や汚れあり"
+              -when 5
+                = "全体的に状態が悪い"
           %tr
             %th 配送料の負担
-            %td=@item.delivery_fee
-              
+            %td
+              -case @item.delivery_fee_id 
+              -when 0
+                = "送料込み(出品者負担)"
+              -when 1
+                = "着払い(購入者負担)"
           %tr
             %th 配送元の地域
             %td=@item.shipping_origin
               
           %tr
             %th 発送日の目安
-            %td=@item.days_to_ship
+            %td
+              -case @item.days_to_ship_id
+              -when 0
+                = "1~2日で発送"
+              -when 1
+                = "2~3日で発送"
+              -when 2
+                = "4~7日で発送"
         -# 追加機能時のビュー、ライクボタン、不適切ボタン。
         -# .ItemBox__ImageBody__OptionArea
         -#   .ItemBox__ImageBody__OptionArea__LikeBtn


### PR DESCRIPTION
# What
1.以下の選択肢に対して、activehashのgemを利用。
商品の状態(condition)
配送料の負担(delivery_fee)
発送までの日数(days_to_ship)

2.1の修正に伴い、商品詳細ページの「商品の状態」「配送料の負担」「発送までの日数」の表示方法をcase文を利用した実装に修正

## 補足
以下部分については吉田さん側で実装を対応していただけるので、このブランチでは修正をしていません。
・商品出品ページの各種プルダウンをactivehashで拾ってくる実装（都道府県のプルダウン以外が該当）
・itemsテーブルにて、activehash化した選択肢のカラム名修正（末尾に"_id"を付与）

# Why
機能要件に、active hashのgemを使う指定があった為、対応