### PR TITLE
商品編集画面のカテゴリー選択の実装

### DIFF
--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -1,93 +1,95 @@
-$(document).ready(function() {
+$(function(){
+  $(document).ready(function() {
 
-  // カテゴリーセレクトボックスのオプションを作成
-  function appendOption(category){
-    var html = `<option value="${category.id}" data-category="${category.id}">${category.name}</option>`;
-    return html;
-  }
-
-
-  // 子カテゴリーの表示作成
-  function appendChidrenBox(insertHTML){
-    var childSelectHtml = '';
-    childSelectHtml = `<div id="children_wrapper">
-                        <select class= 'SellPage__Information__Box__Inner__Form', id= 'child_category' name="item[category_id]">
-                          <option value="---" data-category="---">---</option>
-                          ${insertHTML}
-                      </div>`;
-    $('#PullDownCategory').append(childSelectHtml);
-  }
-
-
-  // 孫カテゴリーの表示作成
-  function appendGrandchidrenBox(insertHTML){
-    var grandchildSelectHtml = '';
-    grandchildSelectHtml = `<div id="grandchildren_wrapper">
-                        <select class= 'SellPage__Information__Box__Inner__Form', id= 'grandchild_category' name="item[category_id]">
-                          <option value="---" data-category="---">---</option>
-                          ${insertHTML}
-                      </div>`;
-    $('#PullDownCategory').append(grandchildSelectHtml);
-  }
-
-
-  $('#parent_category').on('change', function(){
-    // 変数"parentCategory"に、プルダウンで選択した値を代入
-    var parentCategory = document.getElementById('parent_category').value;
-    if(parentCategory != "---"){
-      $.ajax({
-        url: 'get_category_children',
-        type: 'GET',
-        data: { parent_name: parentCategory },
-        dataType: 'json'
-      })
-      .done(function(children){
-        $('#children_wrapper').remove(); //親が変更された時、子以下を削除するする
-        $('#grandchildren_wrapper').remove();
-        var insertHTML = '';
-        children.forEach(function(child){
-          insertHTML += appendOption(child);
-        });
-        appendChidrenBox(insertHTML);
-      })
-      .fail(function(){
-        alert('カテゴリー取得に失敗しました');
-      })
-    }else{
-      $('#children_wrapper').remove(); //親カテゴリーが初期値になった時、子以下を削除するする
-      $('#grandchildren_wrapper').remove();
+    // カテゴリーセレクトボックスのオプションを作成
+    function appendOption(category){
+      var html = `<option value="${category.id}" data-category="${category.id}">${category.name}</option>`;
+      return html;
     }
-  });
 
 
-  // 子カテゴリー選択後のイベント
-  $('#PullDownCategory').on('change', '#child_category', function(){
-    // カテゴリーの子要素に紐づくIDを取得して、そのIDに紐づく孫要素を取得する。
-    // option:selected を指定する事で、プルダウンで選択したものの情報を取得できる事になる。
-    var childId = $('#child_category option:selected').data('category');
-    if (childId != "---"){
-      // 自身で作成したget_category_grandchildrenのルーティングへ飛ばす。その際、プルダウンで選択されている子要素のIDも渡す。
-      $.ajax({
-        url: 'get_category_grandchildren',
-        type: 'GET',
-        data: { child_id: childId },
-        dataType: 'json'
-      })
-      .done(function(grandchildren){
-        if (grandchildren.length != 0) {
-          $('#grandchildren_wrapper').remove(); //子が変更された時、孫以下を削除するする
+    // 子カテゴリーの表示作成
+    function appendChidrenBox(insertHTML){
+      var childSelectHtml = '';
+      childSelectHtml = `<div id="children_wrapper">
+                          <select class= 'SellPage__Information__Box__Inner__Form', id= 'child_category' name="item[category_id]">
+                            <option value="---" data-category="---">---</option>
+                            ${insertHTML}
+                        </div>`;
+      $('#PullDownCategory').append(childSelectHtml);
+    }
+
+
+    // 孫カテゴリーの表示作成
+    function appendGrandchidrenBox(insertHTML){
+      var grandchildSelectHtml = '';
+      grandchildSelectHtml = `<div id="grandchildren_wrapper">
+                          <select class= 'SellPage__Information__Box__Inner__Form', id= 'grandchild_category' name="item[category_id]">
+                            <option value="---" data-category="---">---</option>
+                            ${insertHTML}
+                        </div>`;
+      $('#PullDownCategory').append(grandchildSelectHtml);
+    }
+
+
+    $('#parent_category').on('change', function(){
+      // 変数"parentCategory"に、プルダウンで選択した値を代入
+      var parentCategory = document.getElementById('parent_category').value;
+      if(parentCategory != "---"){
+        $.ajax({
+          url: `get_category_children`,
+          type: 'GET',
+          data: { parent_name: parentCategory },
+          dataType: 'json'
+        })
+        .done(function(children){
+          $('#children_wrapper').remove(); //親が変更された時、子以下を削除するする
+          $('#grandchildren_wrapper').remove();
           var insertHTML = '';
-          grandchildren.forEach(function(grandchild){
-            insertHTML += appendOption(grandchild);
+          children.forEach(function(child){
+            insertHTML += appendOption(child);
           });
-          appendGrandchidrenBox(insertHTML);
-        }
-      })
-      .fail(function(){
-        alert('カテゴリー取得に失敗しました');
-      })
-    }else{
-      $('#grandchildren_wrapper').remove();
-    }
+          appendChidrenBox(insertHTML);
+        })
+        .fail(function(){
+          alert('カテゴリー取得に失敗しました');
+        })
+      }else{
+        $('#children_wrapper').remove(); //親カテゴリーが初期値になった時、子以下を削除するする
+        $('#grandchildren_wrapper').remove();
+      }
+    });
+
+
+    // 子カテゴリー選択後のイベント
+    $('#PullDownCategory').on('change', '#child_category', function(){
+      // カテゴリーの子要素に紐づくIDを取得して、そのIDに紐づく孫要素を取得する。
+      // option:selected を指定する事で、プルダウンで選択したものの情報を取得できる事になる。
+      var childId = $('#child_category option:selected').val();
+      if (childId != "---"){
+        // 自身で作成したget_category_grandchildrenのルーティングへ飛ばす。その際、プルダウンで選択されている子要素のIDも渡す。
+        $.ajax({
+          url: 'get_category_grandchildren',
+          type: 'GET',
+          data: { child_id: childId },
+          dataType: 'json'
+        })
+        .done(function(grandchildren){
+          if (grandchildren.length != 0) {
+            $('#grandchildren_wrapper').remove(); //子が変更された時、孫以下を削除するする
+            var insertHTML = '';
+            grandchildren.forEach(function(grandchild){
+              insertHTML += appendOption(grandchild);
+            });
+            appendGrandchidrenBox(insertHTML);
+          }
+        })
+        .fail(function(){
+          alert('カテゴリー取得に失敗しました');
+        })
+      }else{
+        $('#grandchildren_wrapper').remove();
+      }
+    });
   });
 });

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,6 +38,25 @@ class ItemsController < ApplicationController
       @category_parent_array << parent.name
     end
 
+
+    # 子レコードのプルダウン用に配列で取得
+    @category_children_array = Category.find_by(ancestry: nil).children
+
+    #category_idに紐づいた子レコード（相対関係では親レコード）の取得
+    # 遷移時の初期値設定のため
+    @category_children = Category.find_by(id: @item.category_id).parent
+    
+    #孫レコートのプルダウン用に配列で取得
+    @category_grandchildren_array = Category.find_by(id: @category_children.id).children
+
+    #商品に紐づいている孫カテゴリーIDを取得
+    # 遷移時の初期値設定のため
+    @category_grandchildren = Category.find_by(id: @item.category_id)
+
+    #商品の紐づいている親カテゴリーIDを取得
+    # 遷移時の初期値設定のため
+    @category_parent = Category.find_by(id: @category_children.id).parent
+
     # @item = Item.new
     # #itemテーブルの子テーブルimagesテーブルにもレコードを追加できるように以下もインスタンス化。
     # @item.images.new
@@ -45,8 +64,10 @@ class ItemsController < ApplicationController
 
   def update
     item = Item.find([params[:id]])
+    binding.pry
     item.update(item_params)
-    redirect_to root_path
+    # .update_attributesに書き換えてみたが、結局 undifine method
+
   end
 
   def destroy
@@ -89,7 +110,8 @@ class ItemsController < ApplicationController
 
   #プライベートメソッドにしたいので、private配下に記述
   def item_params
-    params.require(:item).permit(:product_name, :price, :category_id, :condition,:description, :delivery_fee, :shipping_origin, :days_to_ship,:buyer_id, images_attributes: [:image]).merge(user_id: current_user.id, seller_id: current_user.id)
+    params.require(:item).permit(:category,:product_name, :price, :category_id, :condition,:description, :delivery_fee, :shipping_origin, :days_to_ship,:buyer_id, images_attributes: [:image]).merge(user_id: current_user.id, seller_id: current_user.id)
+    binding.pry
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -64,7 +64,6 @@ class ItemsController < ApplicationController
 
   def update
     item = Item.find([params[:id]])
-    binding.pry
     item.update(item_params)
     # .update_attributesに書き換えてみたが、結局 undifine method
 
@@ -111,7 +110,6 @@ class ItemsController < ApplicationController
   #プライベートメソッドにしたいので、private配下に記述
   def item_params
     params.require(:item).permit(:category,:product_name, :price, :category_id, :condition,:description, :delivery_fee, :shipping_origin, :days_to_ship,:buyer_id, images_attributes: [:image]).merge(user_id: current_user.id, seller_id: current_user.id)
-    binding.pry
   end
 
 end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -50,7 +50,12 @@
               カテゴリー
             .SellPage__Information__Box__Inner__SellBox
               必須
-            = f.select :category, @category_parent_array, {}, {class: 'SellPage__Information__Box__Inner__Form', id: 'parent_category'}
+            = f.select :category, @category_parent_array, {selected: @category_parent.name}, {class: 'SellPage__Information__Box__Inner__Form', id: 'parent_category'}
+            #children_wrapper
+              = f.collection_select :category_id, @category_children_array, :id, :name, {},{value: @category_children.id, id: 'child_category', class: "SellPage__Information__Box__Inner__Form"}
+            #grandchildren_wrapper
+              = f.collection_select :category_id, @category_grandchildren_array,:id, :name, {},{value: @category_grandchildren.id, class: 'SellPage__Information__Box__Inner__Form', id: 'grandchild_category'}
+
 
           -# ブランドについては後日実装する為、一旦コメントアウト
           -# .SellPage__Information__Box__Inner

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,10 @@ Rails.application.routes.draw do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
     end
+    member do
+      get 'get_category_children', defaults: { format: 'json' }
+      get 'get_category_grandchildren', defaults: { format: 'json' }
+    end
   end
 end
 


### PR DESCRIPTION
# 変更内容
カテゴリーの挙動がうまくいっていなかったので編集画面用に修正

## 修正内容
初期表示の段階で孫カテゴリーまでデフォルトで表示できる状態に変更。
それに伴い、ルーティングを追加。